### PR TITLE
Move pxeboot config

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,9 +11,6 @@ type Config struct {
 	TemplatePath        string
 	MachinePath         string
 	BaseURL             string
-	ImageURL            string `yaml:"image_url"`
-	Kernel              string
-	Initrd              string
 	ForemanProxyAddress string `yaml:"foreman_proxy_address"`
 	Params              map[string]string
 	PXEConfig           string `yaml:"pxe_config"`

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,5 @@
 templatepath: templates
 machinepath: machines
 baseurl: http://127.0.0.1:9090
-foreman_proxy_address: http://127.0.0.1:8000
 params:
     hello: world

--- a/machines/my-service.example.com.yaml
+++ b/machines/my-service.example.com.yaml
@@ -2,7 +2,13 @@ hostname: my-service.example.com
 operatingsystem: "14.04"
 preseed: preseed.j2
 finish: finish.j2
-
+image_url: http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/
+kernel: linux
+initrd: initrd.gz
+#BaseURL is this waitron instance url, it is read from the config file
+#Hostname is the hostname for this very host, it is read from this file
+#Token is generated at runtime by waitron
+cmdline: "interface=auto url={{ BaseURL }}/{{ Hostname }}/preseed/{{ Token }} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname={{ Hostname }} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US"
 network:
   - name: eth0
     ipaddress: 10.20.30.40


### PR DESCRIPTION
This change allows the image to be booted via pxe to be configured by host as opposed to by watron instance. This would enable to have the pxeboot config in the machine's yaml and to easily boot to a rescue live cd or install other versions/oses.